### PR TITLE
Properly decode Unicode strings

### DIFF
--- a/qbittorrent/client.py
+++ b/qbittorrent/client.py
@@ -78,6 +78,7 @@ class Client(object):
             request = rq.post(final_url, data, **kwargs)
 
         request.raise_for_status()
+        request.encoding = 'utf_8'
 
         if len(request.text) == 0:
             data = json.loads('{}')


### PR DESCRIPTION
qBittorrent WebUI returns data encoded with UTF8, but fails to declare this in the response headers. This is why we must explicitly set an encoding on the request.
Without this patch, filenames containing `µ` are decoded as if they contained `Âľ`.